### PR TITLE
feat: add ollama service and associated volume to compose configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -56,6 +56,16 @@ services:
       options:
         max-size: "20m"
         max-file: "3"
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 1m
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
 
   openfang:
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -37,6 +37,26 @@ services:
         limits:
           memory: 256M
 
+  ollama:
+    image: ollama/ollama:latest
+    profiles:
+      - ollama
+    restart: unless-stopped
+    network_mode: "service:openfang"
+    environment:
+      - OLLAMA_HOST=0.0.0.0:11434
+    volumes:
+      - ollama_data:/root/.ollama
+    depends_on:
+      - openfang
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+
   openfang:
     build:
       context: ./openfang_config
@@ -116,3 +136,5 @@ volumes:
     name: ${CADDY_CONFIG_VOLUME:-caddy_config}
   openfang_data:
     name: ${OPENFANG_DATA_VOLUME:-openfang_data}
+  ollama_data:
+    name: ${OLLAMA_DATA_VOLUME:-ollama_data}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Ollama service to the deployment with persistent model/cache storage and accessibility on port 11434.
* **Stability & Operations**
  * Improved reliability with health checks, resource limits, log rotation, and stricter runtime hardening to ensure stable, self-recovering operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->